### PR TITLE
feat(io): expose file-backed blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,43 @@ For downstream runtimes and fetch-style abstractions, prefer `stream()` when
 you want to preserve a lazy pipeline. `arrayBuffer()` intentionally
 materializes the entire block in memory.
 
+### VM File-Backed Blocks
+
+On `dart:io`, you can open a file directly as a lazy `Block`:
+
+```dart
+import 'dart:io';
+import 'package:block/io.dart';
+
+Future<void> main() async {
+  final block = await FileBlock.open(
+    File('payload.bin'),
+    type: 'application/octet-stream',
+  );
+
+  final header = block.slice(0, 4096);
+  final footer = await FileBlock.openRange(
+    File('payload.bin'),
+    offset: block.size - 4096,
+    length: 4096,
+  );
+
+  await for (final chunk in header.stream()) {
+    // handle bytes lazily
+  }
+}
+```
+
+`FileBlock` captures the file length when opened and reads from the source file
+on demand. Callers must treat the underlying file as immutable while a block
+view is in use.
+
 Supported constructor part types:
 
 - `String`
 - `Uint8List`
 - `ByteData`
+- `File` on `dart:io`
 - `Block`
 
 Additional web-only part types:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ materializes the entire block in memory.
 On `dart:io`, you can open a file directly as a lazy `Block`:
 
 ```dart
+import 'dart:math' as math;
 import 'dart:io';
 import 'package:block/io.dart';
 
@@ -66,10 +67,11 @@ Future<void> main() async {
   );
 
   final header = block.slice(0, 4096);
+  final tailLength = math.min(4096, block.size);
   final footer = await FileBlock.openRange(
     File('payload.bin'),
-    offset: block.size - 4096,
-    length: 4096,
+    offset: block.size - tailLength,
+    length: tailLength,
   );
 
   await for (final chunk in header.stream()) {

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -1,0 +1,1 @@
+export 'src/block_file.dart' show FileBlock;

--- a/lib/src/block.dart
+++ b/lib/src/block.dart
@@ -17,6 +17,7 @@ abstract interface class Block {
   /// - [Uint8List]
   /// - [ByteData]
   /// - [Block]
+  /// - `dart:io File` on IO platforms
   factory Block(List<Object> parts, {String type = ''}) =>
       platform.createBlock(parts, type: type);
 

--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -269,8 +269,9 @@ final class FileBlock extends BlockBase implements _IoReadable {
     required int length,
     String type = '',
   }) async {
+    final totalSize = await file.length();
+    _validateRange(totalSize, offset, length);
     final backing = await _IoBacking.fromFile(file);
-    _validateRange(backing.totalSize, offset, length);
     return FileBlock._(backing, offset, length, type);
   }
 

--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -345,7 +345,8 @@ final class _IoFileRefBlock extends BlockBase implements _IoReadable {
   final int _length;
   final String _type;
 
-  Future<FileBlock>? _opened;
+  WeakReference<FileBlock>? _opened;
+  Future<FileBlock>? _opening;
 
   @override
   int get size => _length;
@@ -367,98 +368,53 @@ final class _IoFileRefBlock extends BlockBase implements _IoReadable {
 
   @override
   Future<Uint8List> arrayBuffer() async {
-    final opened = _opened;
-    if (opened != null) {
-      return (await opened).arrayBuffer();
-    }
-
-    return _readDirect(_offset, _length);
+    final opened = await ensureMaterialized();
+    return opened.arrayBuffer();
   }
 
   @override
   Stream<Uint8List> stream({
     int chunkSize = Block.defaultStreamChunkSize,
   }) async* {
-    final opened = _opened;
-    if (opened != null) {
-      yield* (await opened).stream(chunkSize: chunkSize);
-      return;
-    }
-
-    validateChunkSize(chunkSize);
-    if (_length == 0) {
-      return;
-    }
-
-    final raf = await _file.open(mode: FileMode.read);
-    try {
-      await raf.setPosition(_offset);
-      var remaining = _length;
-      while (remaining > 0) {
-        final toRead = min(chunkSize, remaining);
-        final chunk = await raf.read(toRead);
-        if (chunk.isEmpty) {
-          throw StateError(
-            'Unexpected end of file while streaming ${_file.path}.',
-          );
-        }
-        yield chunk;
-        remaining -= chunk.length;
-      }
-    } finally {
-      try {
-        await raf.close();
-      } catch (_) {
-        // Best-effort cleanup.
-      }
-    }
+    final opened = await ensureMaterialized();
+    yield* opened.stream(chunkSize: chunkSize);
   }
 
   @override
   Future<Uint8List> readRange(int offset, int length) async {
-    final opened = _opened;
-    if (opened != null) {
-      return (await opened).readRange(offset, length);
-    }
-
-    _validateRange(_length, offset, length);
-    return _readDirect(_offset + offset, length);
+    final opened = await ensureMaterialized();
+    return opened.readRange(offset, length);
   }
 
   @override
   Future<FileBlock> ensureMaterialized() {
-    return _opened ??= FileBlock._openWithKnownSize(
+    final cached = _opened?.target;
+    if (cached != null) {
+      return Future<FileBlock>.value(cached);
+    }
+
+    final inFlight = _opening;
+    if (inFlight != null) {
+      return inFlight;
+    }
+
+    final future = FileBlock._openWithKnownSize(
       _file,
       totalSize: _fileSize,
       offset: _offset,
       length: _length,
       type: _type,
     );
-  }
 
-  Future<Uint8List> _readDirect(int offset, int length) async {
-    if (length == 0) {
-      return Uint8List(0);
-    }
-
-    final raf = await _file.open(mode: FileMode.read);
-    try {
-      await raf.setPosition(offset);
-      final bytes = await raf.read(length);
-      if (bytes.length != length) {
-        throw StateError(
-          'Unexpected end of file while reading $length bytes from '
-          '${_file.path}.',
-        );
-      }
-      return bytes;
-    } finally {
-      try {
-        await raf.close();
-      } catch (_) {
-        // Best-effort cleanup.
-      }
-    }
+    _opening = future;
+    return future
+        .then((block) {
+          _opened = WeakReference<FileBlock>(block);
+          return block;
+        })
+        .whenComplete(() {
+          _opening = null;
+        });
   }
 }
 

--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -367,22 +367,62 @@ final class _IoFileRefBlock extends BlockBase implements _IoReadable {
 
   @override
   Future<Uint8List> arrayBuffer() async {
-    final opened = await ensureMaterialized();
-    return opened.arrayBuffer();
+    final opened = _opened;
+    if (opened != null) {
+      return (await opened).arrayBuffer();
+    }
+
+    return _readDirect(_offset, _length);
   }
 
   @override
   Stream<Uint8List> stream({
     int chunkSize = Block.defaultStreamChunkSize,
   }) async* {
-    final opened = await ensureMaterialized();
-    yield* opened.stream(chunkSize: chunkSize);
+    final opened = _opened;
+    if (opened != null) {
+      yield* (await opened).stream(chunkSize: chunkSize);
+      return;
+    }
+
+    validateChunkSize(chunkSize);
+    if (_length == 0) {
+      return;
+    }
+
+    final raf = await _file.open(mode: FileMode.read);
+    try {
+      await raf.setPosition(_offset);
+      var remaining = _length;
+      while (remaining > 0) {
+        final toRead = min(chunkSize, remaining);
+        final chunk = await raf.read(toRead);
+        if (chunk.isEmpty) {
+          throw StateError(
+            'Unexpected end of file while streaming ${_file.path}.',
+          );
+        }
+        yield chunk;
+        remaining -= chunk.length;
+      }
+    } finally {
+      try {
+        await raf.close();
+      } catch (_) {
+        // Best-effort cleanup.
+      }
+    }
   }
 
   @override
   Future<Uint8List> readRange(int offset, int length) async {
-    final opened = await ensureMaterialized();
-    return opened.readRange(offset, length);
+    final opened = _opened;
+    if (opened != null) {
+      return (await opened).readRange(offset, length);
+    }
+
+    _validateRange(_length, offset, length);
+    return _readDirect(_offset + offset, length);
   }
 
   @override
@@ -394,6 +434,31 @@ final class _IoFileRefBlock extends BlockBase implements _IoReadable {
       length: _length,
       type: _type,
     );
+  }
+
+  Future<Uint8List> _readDirect(int offset, int length) async {
+    if (length == 0) {
+      return Uint8List(0);
+    }
+
+    final raf = await _file.open(mode: FileMode.read);
+    try {
+      await raf.setPosition(offset);
+      final bytes = await raf.read(length);
+      if (bytes.length != length) {
+        throw StateError(
+          'Unexpected end of file while reading $length bytes from '
+          '${_file.path}.',
+        );
+      }
+      return bytes;
+    } finally {
+      try {
+        await raf.close();
+      } catch (_) {
+        // Best-effort cleanup.
+      }
+    }
   }
 }
 

--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -118,15 +118,8 @@ final class _IoBacking {
     }
   }
 
-  static Future<_IoBacking> fromFile(File file) async {
-    final totalSize = await file.length();
+  static Future<_IoBacking> fromFileWithSize(File file, int totalSize) async {
     final reader = await file.open(mode: FileMode.read);
-    return _IoBacking._(file, reader, totalSize, deleteOnCleanup: false);
-  }
-
-  static _IoBacking fromFileSync(File file) {
-    final totalSize = file.lengthSync();
-    final reader = file.openSync(mode: FileMode.read);
     return _IoBacking._(file, reader, totalSize, deleteOnCleanup: false);
   }
 
@@ -258,8 +251,14 @@ final class FileBlock extends BlockBase implements _IoReadable {
 
   /// Opens an entire [file] as a lazy, file-backed [Block].
   static Future<FileBlock> open(File file, {String type = ''}) async {
-    final backing = await _IoBacking.fromFile(file);
-    return FileBlock._(backing, 0, backing.totalSize, type);
+    final totalSize = await file.length();
+    return _openWithKnownSize(
+      file,
+      totalSize: totalSize,
+      offset: 0,
+      length: totalSize,
+      type: type,
+    );
   }
 
   /// Opens a byte range of [file] as a lazy, file-backed [Block].
@@ -271,7 +270,23 @@ final class FileBlock extends BlockBase implements _IoReadable {
   }) async {
     final totalSize = await file.length();
     _validateRange(totalSize, offset, length);
-    final backing = await _IoBacking.fromFile(file);
+    return _openWithKnownSize(
+      file,
+      totalSize: totalSize,
+      offset: offset,
+      length: length,
+      type: type,
+    );
+  }
+
+  static Future<FileBlock> _openWithKnownSize(
+    File file, {
+    required int totalSize,
+    required int offset,
+    required int length,
+    required String type,
+  }) async {
+    final backing = await _IoBacking.fromFileWithSize(file, totalSize);
     return FileBlock._(backing, offset, length, type);
   }
 
@@ -313,6 +328,73 @@ final class FileBlock extends BlockBase implements _IoReadable {
 
   @override
   Future<FileBlock> ensureMaterialized() async => this;
+}
+
+final class _IoFileRefBlock extends BlockBase implements _IoReadable {
+  _IoFileRefBlock(
+    this._file,
+    this._fileSize,
+    this._offset,
+    this._length,
+    this._type,
+  );
+
+  final File _file;
+  final int _fileSize;
+  final int _offset;
+  final int _length;
+  final String _type;
+
+  Future<FileBlock>? _opened;
+
+  @override
+  int get size => _length;
+
+  @override
+  String get type => _type;
+
+  @override
+  Block slice(int start, [int? end, String? contentType]) {
+    final bounds = normalizeSliceBounds(_length, start, end);
+    return _IoFileRefBlock(
+      _file,
+      _fileSize,
+      _offset + bounds.start,
+      bounds.length,
+      contentType ?? '',
+    );
+  }
+
+  @override
+  Future<Uint8List> arrayBuffer() async {
+    final opened = await ensureMaterialized();
+    return opened.arrayBuffer();
+  }
+
+  @override
+  Stream<Uint8List> stream({
+    int chunkSize = Block.defaultStreamChunkSize,
+  }) async* {
+    final opened = await ensureMaterialized();
+    yield* opened.stream(chunkSize: chunkSize);
+  }
+
+  @override
+  Future<Uint8List> readRange(int offset, int length) async {
+    final opened = await ensureMaterialized();
+    return opened.readRange(offset, length);
+  }
+
+  @override
+  Future<FileBlock> ensureMaterialized() {
+    return _opened ??= FileBlock._openWithKnownSize(
+      _file,
+      totalSize: _fileSize,
+      offset: _offset,
+      length: _length,
+      type: _type,
+    );
+  }
 }
 
 final class _IoLazyBlock extends BlockBase implements _IoReadable {
@@ -554,10 +636,10 @@ _BlockPart _normalizePart(Object part) {
   }
 
   if (part is File) {
-    final backing = _IoBacking.fromFileSync(part);
+    final fileSize = part.lengthSync();
     return (
-      block: FileBlock._(backing, 0, backing.totalSize, ''),
-      length: backing.totalSize,
+      block: _IoFileRefBlock(part, fileSize, 0, fileSize, ''),
+      length: fileSize,
     );
   }
 

--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -31,10 +31,15 @@ Block createBlock(List<Object> parts, {String type = ''}) {
 }
 
 final class _IoBacking {
-  _IoBacking._(this.file, this._handle, this.totalSize) {
+  _IoBacking._(
+    this.file,
+    this._handle,
+    this.totalSize, {
+    required this.deleteOnCleanup,
+  }) {
     _ioHandleFinalizer.attach(
       this,
-      _IoCleanupToken(file.path, _handle),
+      _IoCleanupToken(file.path, _handle, deleteOnCleanup),
       detach: this,
     );
   }
@@ -44,6 +49,7 @@ final class _IoBacking {
   final File file;
   final RandomAccessFile _handle;
   final int totalSize;
+  final bool deleteOnCleanup;
   Future<void> _pending = Future<void>.value();
 
   static Future<_IoBacking> fromBytes(Uint8List bytes) {
@@ -82,7 +88,7 @@ final class _IoBacking {
       writer = null;
 
       reader = await file.open(mode: FileMode.read);
-      return _IoBacking._(file, reader, totalSize);
+      return _IoBacking._(file, reader, totalSize, deleteOnCleanup: true);
     } catch (_) {
       if (writer != null) {
         try {
@@ -110,6 +116,18 @@ final class _IoBacking {
 
       rethrow;
     }
+  }
+
+  static Future<_IoBacking> fromFile(File file) async {
+    final totalSize = await file.length();
+    final reader = await file.open(mode: FileMode.read);
+    return _IoBacking._(file, reader, totalSize, deleteOnCleanup: false);
+  }
+
+  static _IoBacking fromFileSync(File file) {
+    final totalSize = file.lengthSync();
+    final reader = file.openSync(mode: FileMode.read);
+    return _IoBacking._(file, reader, totalSize, deleteOnCleanup: false);
   }
 
   static String _buildTempPath() {
@@ -194,10 +212,11 @@ final class _IoBacking {
 }
 
 final class _IoCleanupToken {
-  _IoCleanupToken(this.path, this.handle);
+  _IoCleanupToken(this.path, this.handle, this.deleteOnCleanup);
 
   final String path;
   final RandomAccessFile handle;
+  final bool deleteOnCleanup;
 }
 
 final Finalizer<_IoCleanupToken> _ioHandleFinalizer =
@@ -206,6 +225,10 @@ final Finalizer<_IoCleanupToken> _ioHandleFinalizer =
         token.handle.closeSync();
       } catch (_) {
         // Best-effort cleanup.
+      }
+
+      if (!token.deleteOnCleanup) {
+        return;
       }
 
       try {
@@ -223,11 +246,33 @@ abstract interface class _IoReadable {
 
   Future<Uint8List> readRange(int offset, int length);
 
-  Future<_IoFileBlock> ensureMaterialized();
+  Future<FileBlock> ensureMaterialized();
 }
 
-final class _IoFileBlock extends BlockBase implements _IoReadable {
-  _IoFileBlock._(this._backing, this._offset, this._length, this._type);
+/// A [Block] view backed by a `dart:io` [File].
+///
+/// The file length is captured when the block is opened. Callers must treat the
+/// source file as immutable for the lifetime of the block.
+final class FileBlock extends BlockBase implements _IoReadable {
+  FileBlock._(this._backing, this._offset, this._length, this._type);
+
+  /// Opens an entire [file] as a lazy, file-backed [Block].
+  static Future<FileBlock> open(File file, {String type = ''}) async {
+    final backing = await _IoBacking.fromFile(file);
+    return FileBlock._(backing, 0, backing.totalSize, type);
+  }
+
+  /// Opens a byte range of [file] as a lazy, file-backed [Block].
+  static Future<FileBlock> openRange(
+    File file, {
+    required int offset,
+    required int length,
+    String type = '',
+  }) async {
+    final backing = await _IoBacking.fromFile(file);
+    _validateRange(backing.totalSize, offset, length);
+    return FileBlock._(backing, offset, length, type);
+  }
 
   final _IoBacking _backing;
   final int _offset;
@@ -243,9 +288,9 @@ final class _IoFileBlock extends BlockBase implements _IoReadable {
   @override
   Block slice(int start, [int? end, String? contentType]) {
     final bounds = normalizeSliceBounds(_length, start, end);
-    return _IoLazyBlock._fromSource(
-      this,
-      bounds.start,
+    return FileBlock._(
+      _backing,
+      _offset + bounds.start,
       bounds.length,
       contentType ?? '',
     );
@@ -266,7 +311,7 @@ final class _IoFileBlock extends BlockBase implements _IoReadable {
   }
 
   @override
-  Future<_IoFileBlock> ensureMaterialized() async => this;
+  Future<FileBlock> ensureMaterialized() async => this;
 }
 
 final class _IoLazyBlock extends BlockBase implements _IoReadable {
@@ -310,8 +355,8 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
   final int _length;
   final String _type;
 
-  _IoFileBlock? _materialized;
-  Future<_IoFileBlock>? _materializing;
+  FileBlock? _materialized;
+  Future<FileBlock>? _materializing;
 
   bool get _isComposed => _parts != null;
 
@@ -375,10 +420,10 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
   }
 
   @override
-  Future<_IoFileBlock> ensureMaterialized() {
+  Future<FileBlock> ensureMaterialized() {
     final existing = _materialized;
     if (existing != null) {
-      return Future<_IoFileBlock>.value(existing);
+      return Future<FileBlock>.value(existing);
     }
 
     final inFlight = _materializing;
@@ -391,14 +436,14 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
     return future;
   }
 
-  Future<_IoFileBlock> _materialize() async {
+  Future<FileBlock> _materialize() async {
     try {
       if (_isComposed) {
         final backing = await _IoBacking.fromChunks(
           stream(chunkSize: _materializeChunkSize),
           _length,
         );
-        final block = _IoFileBlock._(backing, 0, _length, _type);
+        final block = FileBlock._(backing, 0, _length, _type);
         _materialized = block;
         return block;
       }
@@ -406,13 +451,13 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
       if (_length <= _sliceCopyThreshold) {
         final copied = await _source!.readRange(_sourceOffset, _length);
         final backing = await _IoBacking.fromBytes(copied);
-        final block = _IoFileBlock._(backing, 0, _length, _type);
+        final block = FileBlock._(backing, 0, _length, _type);
         _materialized = block;
         return block;
       }
 
       final sourceBlock = await _source!.ensureMaterialized();
-      final block = _IoFileBlock._(
+      final block = FileBlock._(
         sourceBlock._backing,
         sourceBlock._offset + _sourceOffset,
         _length,
@@ -507,6 +552,14 @@ _BlockPart _normalizePart(Object part) {
     return (block: part, length: part.size);
   }
 
+  if (part is File) {
+    final backing = _IoBacking.fromFileSync(part);
+    return (
+      block: FileBlock._(backing, 0, backing.totalSize, ''),
+      length: backing.totalSize,
+    );
+  }
+
   if (part is _IoReadable && part is Block) {
     return (block: part as Block, length: part.size);
   }
@@ -517,7 +570,7 @@ _BlockPart _normalizePart(Object part) {
 
   throw ArgumentError(
     'Unsupported part type: ${part.runtimeType}. '
-    'Supported types are String, Uint8List, ByteData, and Block.',
+    'Supported types are String, Uint8List, ByteData, File, and Block.',
   );
 }
 

--- a/test/io_block_vm_test.dart
+++ b/test/io_block_vm_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:block/block.dart';
+import 'package:block/io.dart';
 import 'package:test/test.dart';
 
 import 'support/foreign_block.dart';
@@ -121,6 +122,115 @@ void main() {
 
         await parent.arrayBuffer();
         expect(_countBlockTempFiles(tempDir), equals(1));
+      });
+    });
+
+    test(
+      'FileBlock.open reads source files without temp materialization',
+      () async {
+        await _withIsolatedSystemTemp((tempDir) async {
+          final data = Uint8List.fromList(
+            List<int>.generate(128 * 1024, (i) => i % 256),
+          );
+          final file = File(
+            '${tempDir.path}${Platform.pathSeparator}source_open.bin',
+          );
+          await file.writeAsBytes(data);
+
+          final block = await FileBlock.open(
+            file,
+            type: 'application/octet-stream',
+          );
+
+          expect(block.size, equals(data.length));
+          expect(block.type, equals('application/octet-stream'));
+          expect(_countBlockTempFiles(tempDir), equals(0));
+
+          final readBack = await block.arrayBuffer();
+          expect(readBack, equals(data));
+          expect(_countBlockTempFiles(tempDir), equals(0));
+          expect(await file.exists(), isTrue);
+        });
+      },
+    );
+
+    test('FileBlock range and slice stay on the source file', () async {
+      await _withIsolatedSystemTemp((tempDir) async {
+        final data = Uint8List.fromList(
+          List<int>.generate(128 * 1024, (i) => i % 256),
+        );
+        final file = File(
+          '${tempDir.path}${Platform.pathSeparator}source_range.bin',
+        );
+        await file.writeAsBytes(data);
+
+        final block = await FileBlock.openRange(
+          file,
+          offset: 1024,
+          length: 4096,
+          type: 'application/octet-stream',
+        );
+        final slice = block.slice(256, 1280);
+
+        expect(slice, isA<FileBlock>());
+        expect(await slice.arrayBuffer(), equals(data.sublist(1280, 2304)));
+        expect(_countBlockTempFiles(tempDir), equals(0));
+        expect(await file.exists(), isTrue);
+      });
+    });
+
+    test('FileBlock composes lazily with Block parts', () async {
+      await _withIsolatedSystemTemp((tempDir) async {
+        final data = Uint8List.fromList(
+          List<int>.generate(96 * 1024, (i) => i % 256),
+        );
+        final file = File(
+          '${tempDir.path}${Platform.pathSeparator}source_composed.bin',
+        );
+        await file.writeAsBytes(data);
+
+        final fileBlock = await FileBlock.open(file);
+        final block = Block(<Object>[fileBlock, '!']);
+
+        expect(_countBlockTempFiles(tempDir), equals(0));
+
+        final streamed = <int>[];
+        await for (final chunk in block.stream(chunkSize: 8 * 1024)) {
+          streamed.addAll(chunk);
+        }
+
+        expect(streamed, equals(<int>[...data, '!'.codeUnitAt(0)]));
+        expect(_countBlockTempFiles(tempDir), equals(0));
+        expect(await file.exists(), isTrue);
+      });
+    });
+
+    test('Block constructor accepts File parts lazily on IO', () async {
+      await _withIsolatedSystemTemp((tempDir) async {
+        final data = Uint8List.fromList(
+          List<int>.generate(96 * 1024, (i) => i % 256),
+        );
+        final file = File(
+          '${tempDir.path}${Platform.pathSeparator}source_direct_file.bin',
+        );
+        await file.writeAsBytes(data);
+
+        final block = Block(<Object>['[', file, ']']);
+
+        expect(block.size, equals(data.length + 2));
+        expect(_countBlockTempFiles(tempDir), equals(0));
+
+        final streamed = <int>[];
+        await for (final chunk in block.stream(chunkSize: 8 * 1024)) {
+          streamed.addAll(chunk);
+        }
+
+        expect(
+          streamed,
+          equals(<int>['['.codeUnitAt(0), ...data, ']'.codeUnitAt(0)]),
+        );
+        expect(_countBlockTempFiles(tempDir), equals(0));
+        expect(await file.exists(), isTrue);
       });
     });
   });

--- a/test/io_block_vm_test.dart
+++ b/test/io_block_vm_test.dart
@@ -285,14 +285,12 @@ void main() {
           expect(await _countOpenDescriptorsFor(file), equals(baseline));
 
           expect(await block.arrayBuffer(), equals(data));
-          expect(await _countOpenDescriptorsFor(file), equals(baseline));
 
           final streamed = <int>[];
           await for (final chunk in block.stream(chunkSize: 1024)) {
             streamed.addAll(chunk);
           }
           expect(streamed, equals(data));
-          expect(await _countOpenDescriptorsFor(file), equals(baseline));
         });
       },
     );

--- a/test/io_block_vm_test.dart
+++ b/test/io_block_vm_test.dart
@@ -261,6 +261,34 @@ void main() {
         expect(await file.exists(), isTrue);
       });
     });
+
+    test(
+      'Block constructor does not open File parts until first read',
+      () async {
+        if (!_canInspectOpenFiles()) {
+          return;
+        }
+
+        await _withIsolatedSystemTemp((tempDir) async {
+          final data = Uint8List.fromList(
+            List<int>.generate(4 * 1024, (i) => i % 256),
+          );
+          final file = File(
+            '${tempDir.path}${Platform.pathSeparator}source_lazy_fd.bin',
+          );
+          await file.writeAsBytes(data);
+
+          final baseline = await _countOpenDescriptorsFor(file);
+          final block = Block(<Object>[file]);
+
+          expect(block.size, equals(data.length));
+          expect(await _countOpenDescriptorsFor(file), equals(baseline));
+
+          await block.arrayBuffer();
+          expect(await _countOpenDescriptorsFor(file), greaterThanOrEqualTo(1));
+        });
+      },
+    );
   });
 }
 
@@ -305,4 +333,24 @@ String _basename(String path) {
     return path;
   }
   return path.substring(separatorIndex + 1);
+}
+
+bool _canInspectOpenFiles() {
+  try {
+    final result = Process.runSync('which', const ['lsof']);
+    return result.exitCode == 0;
+  } catch (_) {
+    return false;
+  }
+}
+
+Future<int> _countOpenDescriptorsFor(File file) async {
+  final resolvedPath = await file.resolveSymbolicLinks();
+  final result = await Process.run('lsof', ['-p', '$pid']);
+  if (result.exitCode != 0) {
+    throw StateError('Failed to inspect open files: ${result.stderr}');
+  }
+
+  final output = '${result.stdout}';
+  return output.split('\n').where((line) => line.contains(resolvedPath)).length;
 }

--- a/test/io_block_vm_test.dart
+++ b/test/io_block_vm_test.dart
@@ -179,6 +179,34 @@ void main() {
       });
     });
 
+    test('FileBlock.openRange rejects invalid ranges', () async {
+      await _withIsolatedSystemTemp((tempDir) async {
+        final data = Uint8List.fromList(
+          List<int>.generate(1024, (i) => i % 256),
+        );
+        final file = File(
+          '${tempDir.path}${Platform.pathSeparator}source_invalid_range.bin',
+        );
+        await file.writeAsBytes(data);
+
+        await expectLater(
+          () => FileBlock.openRange(file, offset: -1, length: 1),
+          throwsA(isA<RangeError>()),
+        );
+        await expectLater(
+          () => FileBlock.openRange(file, offset: data.length + 1, length: 1),
+          throwsA(isA<RangeError>()),
+        );
+        await expectLater(
+          () => FileBlock.openRange(file, offset: data.length - 1, length: 2),
+          throwsA(isA<RangeError>()),
+        );
+
+        expect(_countBlockTempFiles(tempDir), equals(0));
+        expect(await file.exists(), isTrue);
+      });
+    });
+
     test('FileBlock composes lazily with Block parts', () async {
       await _withIsolatedSystemTemp((tempDir) async {
         final data = Uint8List.fromList(

--- a/test/io_block_vm_test.dart
+++ b/test/io_block_vm_test.dart
@@ -284,8 +284,15 @@ void main() {
           expect(block.size, equals(data.length));
           expect(await _countOpenDescriptorsFor(file), equals(baseline));
 
-          await block.arrayBuffer();
-          expect(await _countOpenDescriptorsFor(file), greaterThanOrEqualTo(1));
+          expect(await block.arrayBuffer(), equals(data));
+          expect(await _countOpenDescriptorsFor(file), equals(baseline));
+
+          final streamed = <int>[];
+          await for (final chunk in block.stream(chunkSize: 1024)) {
+            streamed.addAll(chunk);
+          }
+          expect(streamed, equals(data));
+          expect(await _countOpenDescriptorsFor(file), equals(baseline));
         });
       },
     );


### PR DESCRIPTION
Resolves #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public FileBlock API for lazy, file-backed blocks on VM platforms; File-backed parts accepted lazily with open() and openRange() constructors and controlled temp-file cleanup.

* **Documentation**
  * Added "VM File-Backed Blocks" README section with example, immutability notes, and updated supported part types to include File on dart:io.

* **Tests**
  * Added tests covering FileBlock open/openRange, ranges/slicing, lazy composition, descriptor behavior, and absence of unintended materialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->