### PR TITLE
perf: optimize IO composed range reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock
 webkit/
+benchmark/results/

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 - One minimal, Blob-compatible API surface.
 - `web`: wraps native browser `Blob` via [`package:web`](https://pub.dev/packages/web).
-- `io`: keeps small byte-only blocks in memory and lazily materializes larger/composed blocks to temp files (finalizer cleanup).
+- `io`: keeps small byte-only blocks in memory and lazily materializes file-backed views only when needed (finalizer cleanup).
 - `stream()` is the primary lazy read path; `arrayBuffer()` is the explicit materialized read path.
 - `Block` parts are resolved lazily for `io` composed blocks: bytes are fetched/materialized on first read (`arrayBuffer`/`text`).
 - `slice()` strategy on `io`:
-  - `<= 64KB`: copy to a new temp file
-  - `> 64KB`: share backing file with offset/length view
+  - `<= 64KB`: `arrayBuffer()` reads the source range directly and caches bytes on the slice
+  - `> 64KB`: share backing file with offset/length view when materialized
 
 ## Installation
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -20,7 +20,7 @@ Coverage:
 
 - Creation (`create/single_part_4kb`, `create/single_part_1mb`)
 - Concatenation (`concat/bytes_4x256kb`, `concat/blocks_4x256kb`)
-- Slice threshold paths (`slice/copy_64kb`, `slice/share_256kb`)
+- Slice threshold paths (`slice/small_64kb`, `slice/share_256kb`)
 - Read APIs (`read/array_buffer_8mb`, `read/text_decode_1mb`)
 - Stream APIs (`stream/read_8mb_chunk64kb`, `stream/nested_read_4mb_chunk128kb`)
 - Composition (`compose/from_nested_blocks_4mb`)

--- a/benchmark/block_operations_benchmark.dart
+++ b/benchmark/block_operations_benchmark.dart
@@ -9,7 +9,7 @@ List<BenchmarkScenario> buildOperationScenarios() {
 
   return <BenchmarkScenario>[
     BenchmarkScenario.sync(
-      name: 'slice/copy_64kb',
+      name: 'slice/small_64kb',
       category: 'Slice',
       iterations: 400,
       bytesPerIteration: 64 * 1024,

--- a/benchmark/composition_benchmark.dart
+++ b/benchmark/composition_benchmark.dart
@@ -5,6 +5,24 @@ import 'framework.dart';
 List<BenchmarkScenario> buildCompositionScenarios() {
   final oneMB = makeSequentialBytes(1024 * 1024);
   final nested = Block(<Object>[oneMB, oneMB]);
+  final manySmallParts = List<Object>.generate(
+    1024,
+    (_) => makeSequentialBytes(4 * 1024),
+    growable: false,
+  );
+  final manyPartBlock = Block(manySmallParts);
+  final random4kbOffsets = List<int>.generate(
+    96,
+    (i) => ((i * 37) % 1024) * 4 * 1024,
+    growable: false,
+  );
+  final random64kbOffsets = List<int>.generate(
+    48,
+    (i) => ((i * 29) % (1024 - 16)) * 4 * 1024,
+    growable: false,
+  );
+  var random4kbIndex = 0;
+  var random64kbIndex = 0;
 
   return <BenchmarkScenario>[
     BenchmarkScenario.sync(
@@ -34,6 +52,71 @@ List<BenchmarkScenario> buildCompositionScenarios() {
         }
         if (total != 4 * 1024 * 1024) {
           throw StateError('nested stream mismatch');
+        }
+      },
+    ),
+    BenchmarkScenario.sync(
+      name: 'compose/many_parts_1024x4kb',
+      category: 'Composition',
+      iterations: 80,
+      bytesPerIteration: 4 * 1024 * 1024,
+      maxIterationsPerProcess: 40,
+      action: () {
+        final block = Block(manySmallParts);
+        if (block.size != 4 * 1024 * 1024) {
+          throw StateError('many-part compose size mismatch');
+        }
+      },
+    ),
+    BenchmarkScenario(
+      name: 'range/many_parts_random_slice_4kb',
+      category: 'Range',
+      iterations: 96,
+      bytesPerIteration: 4 * 1024,
+      maxIterationsPerProcess: 48,
+      action: () async {
+        final offset =
+            random4kbOffsets[random4kbIndex++ % random4kbOffsets.length];
+        final bytes = await manyPartBlock
+            .slice(offset, offset + 4 * 1024)
+            .arrayBuffer();
+        if (bytes.length != 4 * 1024 || bytes.first != 0 || bytes.last != 255) {
+          throw StateError('many-part 4KB range mismatch');
+        }
+      },
+    ),
+    BenchmarkScenario(
+      name: 'range/many_parts_random_slice_64kb',
+      category: 'Range',
+      iterations: 48,
+      bytesPerIteration: 64 * 1024,
+      maxIterationsPerProcess: 24,
+      action: () async {
+        final offset =
+            random64kbOffsets[random64kbIndex++ % random64kbOffsets.length];
+        final bytes = await manyPartBlock
+            .slice(offset, offset + 64 * 1024)
+            .arrayBuffer();
+        if (bytes.length != 64 * 1024 ||
+            bytes.first != 0 ||
+            bytes.last != 255) {
+          throw StateError('many-part 64KB range mismatch');
+        }
+      },
+    ),
+    BenchmarkScenario(
+      name: 'stream/many_parts_4mb_chunk64kb',
+      category: 'Stream',
+      iterations: 12,
+      bytesPerIteration: 4 * 1024 * 1024,
+      maxIterationsPerProcess: 12,
+      action: () async {
+        var total = 0;
+        await for (final chunk in manyPartBlock.stream(chunkSize: 64 * 1024)) {
+          total += chunk.length;
+        }
+        if (total != 4 * 1024 * 1024) {
+          throw StateError('many-part stream mismatch');
         }
       },
     ),

--- a/benchmark/composition_benchmark.dart
+++ b/benchmark/composition_benchmark.dart
@@ -73,7 +73,7 @@ List<BenchmarkScenario> buildCompositionScenarios() {
       category: 'Range',
       iterations: 96,
       bytesPerIteration: 4 * 1024,
-      maxIterationsPerProcess: 48,
+      // Keep the deterministic offset sequence in one worker process.
       action: () async {
         final offset =
             random4kbOffsets[random4kbIndex++ % random4kbOffsets.length];
@@ -90,7 +90,6 @@ List<BenchmarkScenario> buildCompositionScenarios() {
       category: 'Range',
       iterations: 48,
       bytesPerIteration: 64 * 1024,
-      maxIterationsPerProcess: 24,
       action: () async {
         final offset =
             random64kbOffsets[random64kbIndex++ % random64kbOffsets.length];

--- a/benchmark/framework.dart
+++ b/benchmark/framework.dart
@@ -1,3 +1,4 @@
+import 'dart:developer' as developer;
 import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data';
@@ -182,6 +183,16 @@ final class BenchmarkEnvironment {
   final String dartVersion;
   final int cpuCount;
   final String tempDirectory;
+
+  Map<String, Object?> toJson() {
+    return {
+      'os': os,
+      'os_version': osVersion,
+      'dart_version': dartVersion,
+      'cpu_count': cpuCount,
+      'temp_directory': tempDirectory,
+    };
+  }
 }
 
 final class BenchmarkRun {
@@ -194,59 +205,115 @@ final class BenchmarkRun {
   final DateTime generatedAtUtc;
   final BenchmarkEnvironment environment;
   final List<BenchmarkScenarioResult> scenarios;
+
+  Map<String, Object?> toJson() {
+    return {
+      'generated_at_utc': generatedAtUtc.toIso8601String(),
+      'environment': environment.toJson(),
+      'scenarios': [for (final scenario in scenarios) scenario.toJson()],
+    };
+  }
 }
 
-Future<BenchmarkScenarioResult> runScenario(BenchmarkScenario scenario) async {
+Future<BenchmarkScenarioResult> runScenario(
+  BenchmarkScenario scenario, {
+  bool useTimeline = false,
+}) async {
   const tempPrefix = 'block_io_';
+  final task = useTimeline
+      ? developer.TimelineTask(filterKey: 'block.benchmark')
+      : null;
   final tempFilesBefore = _countTempFilesWithPrefix(tempPrefix);
   final rssBefore = _safeCurrentRss();
   var rssPeak = rssBefore;
 
-  for (var i = 0; i < scenario.warmup; i++) {
-    await scenario.action();
-    final rssNow = _safeCurrentRss();
-    if (rssNow > rssPeak) {
-      rssPeak = rssNow;
-    }
-  }
-
-  final iterationUs = <double>[];
-  for (var i = 0; i < scenario.iterations; i++) {
-    final watch = Stopwatch()..start();
-    await scenario.action();
-    watch.stop();
-    iterationUs.add(watch.elapsedMicroseconds.toDouble());
-
-    final rssNow = _safeCurrentRss();
-    if (rssNow > rssPeak) {
-      rssPeak = rssNow;
-    }
-  }
-
-  final totalUs = iterationUs.fold<double>(0, (sum, current) => sum + current);
-  final sortedLatencies = iterationUs.toList()..sort();
-  final tempFilesAfter = _countTempFilesWithPrefix(tempPrefix);
-  final rssAfter = _safeCurrentRss();
-
-  return BenchmarkScenarioResult(
-    name: scenario.name,
-    category: scenario.category,
-    iterations: scenario.iterations,
-    warmup: scenario.warmup,
-    totalUs: totalUs,
-    avgUs: scenario.iterations == 0 ? 0 : totalUs / scenario.iterations,
-    p50Us: _percentile(sortedLatencies, 0.50),
-    p95Us: _percentile(sortedLatencies, 0.95),
-    p99Us: _percentile(sortedLatencies, 0.99),
-    bytesPerIteration: scenario.bytesPerIteration,
-    tempFilesBefore: tempFilesBefore,
-    tempFilesAfter: tempFilesAfter,
-    tempFilesDelta: tempFilesAfter - tempFilesBefore,
-    rssBeforeBytes: rssBefore,
-    rssAfterBytes: rssAfter,
-    rssPeakBytes: rssPeak,
-    samplesUs: iterationUs,
+  task?.start(
+    'block.benchmark.scenario',
+    arguments: {
+      'scenario': scenario.name,
+      'category': scenario.category,
+      'iterations': scenario.iterations,
+      'warmup': scenario.warmup,
+    },
   );
+
+  var scenarioFinished = false;
+  try {
+    for (var i = 0; i < scenario.warmup; i++) {
+      await _runScenarioAction(
+        scenario,
+        task: task,
+        phase: 'warmup',
+        iteration: i,
+      );
+      final rssNow = _safeCurrentRss();
+      if (rssNow > rssPeak) {
+        rssPeak = rssNow;
+      }
+    }
+
+    final iterationUs = <double>[];
+    for (var i = 0; i < scenario.iterations; i++) {
+      final watch = Stopwatch()..start();
+      await _runScenarioAction(
+        scenario,
+        task: task,
+        phase: 'iteration',
+        iteration: i,
+      );
+      watch.stop();
+      iterationUs.add(watch.elapsedMicroseconds.toDouble());
+
+      final rssNow = _safeCurrentRss();
+      if (rssNow > rssPeak) {
+        rssPeak = rssNow;
+      }
+    }
+
+    final totalUs = iterationUs.fold<double>(
+      0,
+      (sum, current) => sum + current,
+    );
+    final sortedLatencies = iterationUs.toList()..sort();
+    final tempFilesAfter = _countTempFilesWithPrefix(tempPrefix);
+    final rssAfter = _safeCurrentRss();
+
+    final result = BenchmarkScenarioResult(
+      name: scenario.name,
+      category: scenario.category,
+      iterations: scenario.iterations,
+      warmup: scenario.warmup,
+      totalUs: totalUs,
+      avgUs: scenario.iterations == 0 ? 0 : totalUs / scenario.iterations,
+      p50Us: _percentile(sortedLatencies, 0.50),
+      p95Us: _percentile(sortedLatencies, 0.95),
+      p99Us: _percentile(sortedLatencies, 0.99),
+      bytesPerIteration: scenario.bytesPerIteration,
+      tempFilesBefore: tempFilesBefore,
+      tempFilesAfter: tempFilesAfter,
+      tempFilesDelta: tempFilesAfter - tempFilesBefore,
+      rssBeforeBytes: rssBefore,
+      rssAfterBytes: rssAfter,
+      rssPeakBytes: rssPeak,
+      samplesUs: iterationUs,
+    );
+
+    scenarioFinished = true;
+    task?.finish(
+      arguments: {
+        'avg_us': result.avgUs,
+        'p95_us': result.p95Us,
+        'temp_files_delta': result.tempFilesDelta,
+        'rss_peak_bytes': result.rssPeakBytes,
+      },
+    );
+
+    return result;
+  } finally {
+    if (task != null && !scenarioFinished) {
+      task.finish(arguments: {'failed': true});
+    }
+  }
 }
 
 BenchmarkScenarioResult mergeScenarioChunks(
@@ -312,6 +379,28 @@ Future<BenchmarkRun> runBenchmarks(List<BenchmarkScenario> scenarios) async {
     environment: environment,
     scenarios: results,
   );
+}
+
+Future<void> _runScenarioAction(
+  BenchmarkScenario scenario, {
+  required developer.TimelineTask? task,
+  required String phase,
+  required int iteration,
+}) async {
+  if (task == null) {
+    await scenario.action();
+    return;
+  }
+
+  task.start(
+    'block.benchmark.$phase',
+    arguments: {'scenario': scenario.name, 'iteration': iteration},
+  );
+  try {
+    await scenario.action();
+  } finally {
+    task.finish();
+  }
 }
 
 void printBenchmarkReport(BenchmarkRun run, {bool useColors = true}) {

--- a/benchmark/run_all.dart
+++ b/benchmark/run_all.dart
@@ -12,8 +12,8 @@ import 'framework.dart';
 Future<void> main(List<String> args) async {
   final parsed = Args.parse(
     args,
-    bool: const ['help', 'no-color', 'worker'],
-    string: const ['scenario', 'iterations', 'warmup'],
+    bool: const ['help', 'no-color', 'timeline', 'worker'],
+    string: const ['output', 'scenario', 'iterations', 'warmup'],
     aliases: const {'h': 'help'},
   );
 
@@ -24,10 +24,14 @@ Future<void> main(List<String> args) async {
     print('  dart benchmark/run_all.dart [--no-color]');
     print('');
     print('Options:');
-    print('  --no-color    Disable ANSI styling.');
-    print('  -h, --help    Show this help.');
+    print('  --no-color       Disable ANSI styling.');
+    print('  --output=<path>  Write machine-readable JSON results.');
+    print('  --timeline       Emit dart:developer timeline events.');
+    print('  -h, --help       Show this help.');
     return;
   }
+
+  final useTimeline = (parsed['timeline']?.safeAs<bool>()) ?? false;
 
   final scenarios = <BenchmarkScenario>[
     ...buildCreationScenarios(),
@@ -67,22 +71,31 @@ Future<void> main(List<String> args) async {
       action: source.action,
     );
 
-    final result = await runScenario(workerScenario);
+    final result = await runScenario(workerScenario, useTimeline: useTimeline);
     print('WORKER_RESULT_JSON=${jsonEncode(result.toJson())}');
     return;
   }
 
-  final run = await _runBenchmarksWithWorkers(scenarios);
+  final run = await _runBenchmarksWithWorkers(
+    scenarios,
+    useTimeline: useTimeline,
+  );
 
   printBenchmarkReport(
     run,
     useColors: !((parsed['no-color']?.safeAs<bool>()) ?? false),
   );
+
+  final outputPath = parsed['output']?.safeAs<String>();
+  if (outputPath != null && outputPath.isNotEmpty) {
+    await _writeBenchmarkJson(outputPath, run);
+  }
 }
 
 Future<BenchmarkRun> _runBenchmarksWithWorkers(
-  List<BenchmarkScenario> scenarios,
-) async {
+  List<BenchmarkScenario> scenarios, {
+  required bool useTimeline,
+}) async {
   final environment = BenchmarkEnvironment.capture();
   final results = <BenchmarkScenarioResult>[];
 
@@ -94,6 +107,7 @@ Future<BenchmarkRun> _runBenchmarksWithWorkers(
           scenario: scenario,
           iterations: scenario.iterations,
           warmup: scenario.warmup,
+          useTimeline: useTimeline,
         ),
       );
       continue;
@@ -110,6 +124,7 @@ Future<BenchmarkRun> _runBenchmarksWithWorkers(
           scenario: scenario,
           iterations: chunkIterations,
           warmup: first ? scenario.warmup : 0,
+          useTimeline: useTimeline,
         ),
       );
       remaining -= chunkIterations;
@@ -130,6 +145,7 @@ Future<BenchmarkScenarioResult> _runWorkerChunk({
   required BenchmarkScenario scenario,
   required int iterations,
   required int warmup,
+  required bool useTimeline,
 }) async {
   final scriptPath = Platform.script.toFilePath();
   final workerArgs = <String>[
@@ -141,6 +157,9 @@ Future<BenchmarkScenarioResult> _runWorkerChunk({
     '--warmup=$warmup',
     '--no-color',
   ];
+  if (useTimeline) {
+    workerArgs.add('--timeline');
+  }
 
   final result = await Process.run(
     Platform.resolvedExecutable,
@@ -180,6 +199,17 @@ Future<BenchmarkScenarioResult> _runWorkerChunk({
     return BenchmarkScenarioResult.fromJson(decoded.cast<String, Object?>());
   }
   throw StateError('Unexpected worker payload for ${scenario.name}.');
+}
+
+Future<void> _writeBenchmarkJson(String outputPath, BenchmarkRun run) async {
+  final file = File(outputPath);
+  final parent = file.parent;
+  if (!await parent.exists()) {
+    await parent.create(recursive: true);
+  }
+
+  const encoder = JsonEncoder.withIndent('  ');
+  await file.writeAsString('${encoder.convert(run.toJson())}\n');
 }
 
 int _parseIntArg(String? raw, {required int fallback}) {

--- a/integration_test/block_io_integration_test.dart
+++ b/integration_test/block_io_integration_test.dart
@@ -33,20 +33,20 @@ void main() {
 
       final smallBytes = await smallSlice.arrayBuffer();
       expect(smallBytes, equals(source.sublist(0, 1024)));
-      expect(_countBlockTempFiles(tempDir), equals(1));
+      expect(_countBlockTempFiles(tempDir), equals(0));
 
       final largeBytes = await largeSlice.arrayBuffer();
       expect(largeBytes, equals(source.sublist(0, 128 * 1024)));
-      expect(_countBlockTempFiles(tempDir), equals(2));
+      expect(_countBlockTempFiles(tempDir), equals(1));
 
       final parentBytes = await block.arrayBuffer();
       expect(parentBytes, equals(source));
-      expect(_countBlockTempFiles(tempDir), equals(2));
+      expect(_countBlockTempFiles(tempDir), equals(1));
 
       final textBlock = Block(<Object>['abc']);
-      expect(_countBlockTempFiles(tempDir), equals(2));
+      expect(_countBlockTempFiles(tempDir), equals(1));
       expect(await textBlock.text(), equals('abc'));
-      expect(_countBlockTempFiles(tempDir), equals(2));
+      expect(_countBlockTempFiles(tempDir), equals(1));
     });
   });
 }

--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -533,11 +533,11 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
     if (!_isComposed && _length <= _sliceCopyThreshold) {
       final cached = _smallSourceBytes;
       if (cached != null) {
-        return cached;
+        return Uint8List.fromList(cached);
       }
 
       final bytes = await _source!.readRange(_sourceOffset, _length);
-      _smallSourceBytes = bytes;
+      _smallSourceBytes = Uint8List.fromList(bytes);
       return bytes;
     }
 

--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -16,6 +16,45 @@ const int _materializeChunkSize = 1024 * 1024;
 
 typedef _BlockPart = ({Block block, int length});
 
+final class _IoPartIndex {
+  _IoPartIndex(this.parts) : _starts = _buildStarts(parts);
+
+  final List<_BlockPart> parts;
+  final List<int> _starts;
+
+  int startAt(int index) => _starts[index];
+
+  int findPartIndex(int offset) {
+    var low = 0;
+    var high = parts.length - 1;
+
+    while (low <= high) {
+      final mid = low + ((high - low) >> 1);
+      final start = _starts[mid];
+      final end = start + parts[mid].length;
+
+      if (offset < start) {
+        high = mid - 1;
+      } else if (offset >= end) {
+        low = mid + 1;
+      } else {
+        return mid;
+      }
+    }
+
+    return parts.length;
+  }
+
+  static List<int> _buildStarts(List<_BlockPart> parts) {
+    var offset = 0;
+    return List<int>.generate(parts.length, (index) {
+      final start = offset;
+      offset += parts[index].length;
+      return start;
+    }, growable: false);
+  }
+}
+
 Block createBlock(List<Object> parts, {String type = ''}) {
   final memory = MemoryBlock.tryFromParts(
     parts,
@@ -419,8 +458,10 @@ final class _IoFileRefBlock extends BlockBase implements _IoReadable {
 }
 
 final class _IoLazyBlock extends BlockBase implements _IoReadable {
-  _IoLazyBlock._fromParts(this._parts, this._length, this._type)
-    : _source = null,
+  _IoLazyBlock._fromParts(List<_BlockPart> parts, this._length, this._type)
+    : _parts = parts,
+      _partIndex = _IoPartIndex(parts),
+      _source = null,
       _sourceOffset = 0;
 
   _IoLazyBlock._fromSourceRaw(
@@ -428,7 +469,8 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
     this._sourceOffset,
     this._length,
     this._type,
-  ) : _parts = null;
+  ) : _parts = null,
+      _partIndex = null;
 
   factory _IoLazyBlock._fromSource(
     _IoReadable source,
@@ -454,6 +496,7 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
   }
 
   final List<_BlockPart>? _parts;
+  final _IoPartIndex? _partIndex;
   final _IoReadable? _source;
   final int _sourceOffset;
   final int _length;
@@ -498,7 +541,7 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
   }) async* {
     if (_isComposed) {
       validateChunkSize(chunkSize);
-      for (final part in _parts!) {
+      for (final part in _partIndex!.parts) {
         yield* part.block.stream(chunkSize: chunkSize);
       }
       return;
@@ -582,20 +625,19 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
 
     final output = Uint8List(length);
     var outputOffset = 0;
-    var remainingSkip = offset;
     var remainingLength = length;
 
-    for (final part in _parts!) {
+    final partIndex = _partIndex!;
+    var index = partIndex.findPartIndex(offset);
+    var absoluteOffset = offset;
+
+    while (index < partIndex.parts.length) {
       if (remainingLength == 0) {
         break;
       }
 
-      if (remainingSkip >= part.length) {
-        remainingSkip -= part.length;
-        continue;
-      }
-
-      final localStart = remainingSkip;
+      final part = partIndex.parts[index];
+      final localStart = absoluteOffset - partIndex.startAt(index);
       final available = part.length - localStart;
       final take = min(available, remainingLength);
       final segment = await _readBlockRange(part.block, localStart, take);
@@ -603,7 +645,8 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
 
       outputOffset += take;
       remainingLength -= take;
-      remainingSkip = 0;
+      absoluteOffset += take;
+      index++;
     }
 
     return output;

--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -460,7 +460,6 @@ final class _IoFileRefBlock extends BlockBase implements _IoReadable {
 final class _IoLazyBlock extends BlockBase implements _IoReadable {
   _IoLazyBlock._fromParts(List<_BlockPart> parts, this._length, this._type)
     : _parts = parts,
-      _partIndex = _IoPartIndex(parts),
       _source = null,
       _sourceOffset = 0;
 
@@ -469,8 +468,7 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
     this._sourceOffset,
     this._length,
     this._type,
-  ) : _parts = null,
-      _partIndex = null;
+  ) : _parts = null;
 
   factory _IoLazyBlock._fromSource(
     _IoReadable source,
@@ -496,12 +494,13 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
   }
 
   final List<_BlockPart>? _parts;
-  final _IoPartIndex? _partIndex;
   final _IoReadable? _source;
   final int _sourceOffset;
   final int _length;
   final String _type;
 
+  _IoPartIndex? _partIndex;
+  Uint8List? _smallSourceBytes;
   FileBlock? _materialized;
   Future<FileBlock>? _materializing;
 
@@ -531,6 +530,17 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
 
   @override
   Future<Uint8List> arrayBuffer() async {
+    if (!_isComposed && _length <= _sliceCopyThreshold) {
+      final cached = _smallSourceBytes;
+      if (cached != null) {
+        return cached;
+      }
+
+      final bytes = await _source!.readRange(_sourceOffset, _length);
+      _smallSourceBytes = bytes;
+      return bytes;
+    }
+
     final materialized = await ensureMaterialized();
     return materialized.arrayBuffer();
   }
@@ -541,7 +551,7 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
   }) async* {
     if (_isComposed) {
       validateChunkSize(chunkSize);
-      for (final part in _partIndex!.parts) {
+      for (final part in _parts!) {
         yield* part.block.stream(chunkSize: chunkSize);
       }
       return;
@@ -627,7 +637,7 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
     var outputOffset = 0;
     var remainingLength = length;
 
-    final partIndex = _partIndex!;
+    final partIndex = _partIndex ??= _IoPartIndex(_parts!);
     var index = partIndex.findPartIndex(offset);
     var absoluteOffset = offset;
 

--- a/test/io_block_vm_test.dart
+++ b/test/io_block_vm_test.dart
@@ -54,10 +54,10 @@ void main() {
         expect(_countBlockTempFiles(tempDir), equals(0));
 
         expect(await slice.text(), equals('child'));
-        expect(_countBlockTempFiles(tempDir), equals(1));
+        expect(_countBlockTempFiles(tempDir), equals(0));
 
         expect(await parent.text(), equals('[child]'));
-        expect(_countBlockTempFiles(tempDir), equals(2));
+        expect(_countBlockTempFiles(tempDir), equals(1));
       });
     });
 
@@ -87,7 +87,7 @@ void main() {
       },
     );
 
-    test('slice <= 64KB copies into a new temp file', () async {
+    test('slice <= 64KB arrayBuffer reads without temp files', () async {
       await _withIsolatedSystemTemp((tempDir) async {
         final data = Uint8List.fromList(
           List<int>.generate(200 * 1024, (i) => i % 256),
@@ -99,10 +99,10 @@ void main() {
 
         final bytes = await child.arrayBuffer();
         expect(bytes, equals(data.sublist(1024, 2048)));
-        expect(_countBlockTempFiles(tempDir), equals(1));
+        expect(_countBlockTempFiles(tempDir), equals(0));
 
         await parent.arrayBuffer();
-        expect(_countBlockTempFiles(tempDir), equals(2));
+        expect(_countBlockTempFiles(tempDir), equals(1));
       });
     });
 
@@ -253,7 +253,7 @@ void main() {
         expect(block.size, equals(data.length));
         expect(_countBlockTempFiles(tempDir), equals(0));
         expect(await slice.arrayBuffer(), equals(data.sublist(start, end)));
-        expect(_countBlockTempFiles(tempDir), equals(1));
+        expect(_countBlockTempFiles(tempDir), equals(0));
       });
     });
 

--- a/test/io_block_vm_test.dart
+++ b/test/io_block_vm_test.dart
@@ -233,6 +233,30 @@ void main() {
       });
     });
 
+    test('many-part slices read across composed ranges', () async {
+      await _withIsolatedSystemTemp((tempDir) async {
+        final data = Uint8List.fromList(
+          List<int>.generate(128 * 1024, (i) => i % 256),
+        );
+        final parts = List<Object>.generate(
+          128,
+          (index) =>
+              Uint8List.sublistView(data, index * 1024, (index + 1) * 1024),
+          growable: false,
+        );
+
+        final block = Block(parts);
+        final start = (100 * 1024) + 900;
+        final end = start + 5000;
+        final slice = block.slice(start, end);
+
+        expect(block.size, equals(data.length));
+        expect(_countBlockTempFiles(tempDir), equals(0));
+        expect(await slice.arrayBuffer(), equals(data.sublist(start, end)));
+        expect(_countBlockTempFiles(tempDir), equals(1));
+      });
+    });
+
     test('Block constructor accepts File parts lazily on IO', () async {
       await _withIsolatedSystemTemp((tempDir) async {
         final data = Uint8List.fromList(

--- a/test/io_block_vm_test.dart
+++ b/test/io_block_vm_test.dart
@@ -106,6 +106,22 @@ void main() {
       });
     });
 
+    test('slice <= 64KB cached bytes stay immutable across reads', () async {
+      await _withIsolatedSystemTemp((tempDir) async {
+        final data = Uint8List.fromList(
+          List<int>.generate(200 * 1024, (i) => i % 256),
+        );
+        final child = Block(<Object>[data]).slice(1024, 1024 + 1024);
+
+        final first = await child.arrayBuffer();
+        first[0] = 42;
+
+        final second = await child.arrayBuffer();
+        expect(second, equals(data.sublist(1024, 2048)));
+        expect(_countBlockTempFiles(tempDir), equals(0));
+      });
+    });
+
     test('slice > 64KB shares parent materialized file', () async {
       await _withIsolatedSystemTemp((tempDir) async {
         final data = Uint8List.fromList(


### PR DESCRIPTION
## Summary

- add an internal, lazy prefix index for IO composed block parts so range reads can jump to the first relevant segment instead of linearly skipping from the beginning
- avoid temp-file materialization for small IO source-view `arrayBuffer()` reads by reading and caching the source range directly, while keeping cached bytes private from caller mutation
- add #13-focused many-part composition, range, and stream benchmark scenarios
- add benchmark JSON output plus optional `dart:developer` timeline events for profiling
- cover many-part cross-segment slices, immutable cached slice bytes, and updated small-slice temp-file behavior in tests

Closes #13

## Validation

- `git diff --check`
- `dart analyze`
- `dart test`
- `dart benchmark/run_all.dart --no-color --output=benchmark/results/experiment-segment-index-no-timeline.json`
- `dart benchmark/run_all.dart --no-color --timeline --output=benchmark/results/experiment-segment-index.json`

Note: `flutter test integration_test` was attempted from `integration_test/`, but this environment has no supported Flutter device/platform target for that integration project. GitHub Actions did run Flutter Integration Tests successfully after the earlier push.

## Baseline Notes

After fixing review feedback about benchmark worker chunking, pure performance was compared against a same-benchmark baseline from `main`:

- `range/many_parts_random_slice_4kb`: avg -97.6%, p95 -97.8%, temp/iter 0.375 -> 0
- `range/many_parts_random_slice_64kb`: avg -89.3%, p95 -88.1%, temp/iter 0.583 -> 0
- `stream/many_parts_4mb_chunk64kb`: avg -3.7%, p95 -7.8% in this run
- target range-scenario RSS stayed effectively flat to slightly lower
- no public `Block` API change