### PR TITLE
perf: optimize IO composed storage hot paths

### DIFF
--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -751,7 +751,12 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
       continue;
     }
 
-    normalized.add(normalizedPart);
+    final flattenedParts = _flattenedComposedParts(normalizedPart.block);
+    if (flattenedParts == null) {
+      normalized.add(normalizedPart);
+    } else {
+      normalized.addAll(flattenedParts);
+    }
     totalSize += normalizedPart.length;
   }
 
@@ -759,6 +764,18 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
     parts: List<_BlockPart>.unmodifiable(normalized),
     totalSize: totalSize,
   );
+}
+
+List<_BlockPart>? _flattenedComposedParts(Block block) {
+  if (block is! _IoLazyBlock || !block._isComposed) {
+    return null;
+  }
+
+  if (block._materialized != null || block._materializing != null) {
+    return null;
+  }
+
+  return block._parts;
 }
 
 _BlockPart _normalizePart(Object part) {

--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -676,8 +676,18 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
       final localStart = absoluteOffset - partIndex.startAt(index);
       final available = part.length - localStart;
       final take = min(available, remainingLength);
-      final segment = await _readBlockRange(part.block, localStart, take);
-      output.setRange(outputOffset, outputOffset + take, segment);
+      final block = part.block;
+      if (block is MemoryBlock) {
+        output.setRange(
+          outputOffset,
+          outputOffset + take,
+          block.copyBytesSync(),
+          localStart,
+        );
+      } else {
+        final segment = await _readBlockRange(block, localStart, take);
+        output.setRange(outputOffset, outputOffset + take, segment);
+      }
 
       outputOffset += take;
       remainingLength -= take;

--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -233,35 +233,14 @@ final class _IoBacking {
     int offset,
     int length, {
     required int chunkSize,
-  }) async* {
-    validateChunkSize(chunkSize);
-    _validateRange(totalSize, offset, length);
-    if (length == 0) {
-      return;
-    }
-
-    final raf = await file.open(mode: FileMode.read);
-    try {
-      await raf.setPosition(offset);
-      var remaining = length;
-      while (remaining > 0) {
-        final toRead = min(chunkSize, remaining);
-        final chunk = await raf.read(toRead);
-        if (chunk.isEmpty) {
-          throw StateError(
-            'Unexpected end of file while streaming ${file.path}.',
-          );
-        }
-        yield chunk;
-        remaining -= chunk.length;
-      }
-    } finally {
-      try {
-        await raf.close();
-      } catch (_) {
-        // Best-effort cleanup.
-      }
-    }
+  }) {
+    return _streamFileRange(
+      file,
+      totalSize,
+      offset,
+      length,
+      chunkSize: chunkSize,
+    );
   }
 
   Future<T> _enqueue<T>(Future<T> Function() action) {
@@ -453,11 +432,14 @@ final class _IoFileRefBlock extends BlockBase implements _IoReadable {
   }
 
   @override
-  Stream<Uint8List> stream({
-    int chunkSize = Block.defaultStreamChunkSize,
-  }) async* {
-    final opened = await ensureMaterialized();
-    yield* opened.stream(chunkSize: chunkSize);
+  Stream<Uint8List> stream({int chunkSize = Block.defaultStreamChunkSize}) {
+    return _streamFileRange(
+      _file,
+      _fileSize,
+      _offset,
+      _length,
+      chunkSize: chunkSize,
+    );
   }
 
   @override
@@ -832,6 +814,43 @@ Future<Uint8List> _readBlockRange(Block block, int offset, int length) {
   }
 
   return block.slice(offset, offset + length).arrayBuffer();
+}
+
+Stream<Uint8List> _streamFileRange(
+  File file,
+  int totalSize,
+  int offset,
+  int length, {
+  required int chunkSize,
+}) async* {
+  validateChunkSize(chunkSize);
+  _validateRange(totalSize, offset, length);
+  if (length == 0) {
+    return;
+  }
+
+  final raf = await file.open(mode: FileMode.read);
+  try {
+    await raf.setPosition(offset);
+    var remaining = length;
+    while (remaining > 0) {
+      final toRead = min(chunkSize, remaining);
+      final chunk = await raf.read(toRead);
+      if (chunk.isEmpty) {
+        throw StateError(
+          'Unexpected end of file while streaming ${file.path}.',
+        );
+      }
+      yield chunk;
+      remaining -= chunk.length;
+    }
+  } finally {
+    try {
+      await raf.close();
+    } catch (_) {
+      // Best-effort cleanup.
+    }
+  }
 }
 
 void _validateRange(int totalSize, int offset, int length) {

--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -55,6 +55,47 @@ final class _IoPartIndex {
   }
 }
 
+final class _ChunkCoalescer {
+  _ChunkCoalescer(this.chunkSize);
+
+  final int chunkSize;
+  final BytesBuilder _builder = BytesBuilder(copy: false);
+
+  Iterable<Uint8List> add(Uint8List chunk) sync* {
+    if (chunk.isEmpty) {
+      return;
+    }
+
+    var offset = 0;
+    while (offset < chunk.length) {
+      if (_builder.length == 0) {
+        final remaining = chunk.length - offset;
+        if (remaining >= chunkSize) {
+          final next = offset + chunkSize;
+          yield Uint8List.sublistView(chunk, offset, next);
+          offset = next;
+          continue;
+        }
+      }
+
+      final take = min(chunkSize - _builder.length, chunk.length - offset);
+      _builder.add(Uint8List.sublistView(chunk, offset, offset + take));
+      offset += take;
+
+      if (_builder.length == chunkSize) {
+        yield _builder.takeBytes();
+      }
+    }
+  }
+
+  Uint8List? finish() {
+    if (_builder.length == 0) {
+      return null;
+    }
+    return _builder.takeBytes();
+  }
+}
+
 Block createBlock(List<Object> parts, {String type = ''}) {
   final memory = MemoryBlock.tryFromParts(
     parts,
@@ -551,14 +592,17 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
   }) async* {
     if (_isComposed) {
       validateChunkSize(chunkSize);
-      for (final part in _parts!) {
-        yield* part.block.stream(chunkSize: chunkSize);
+      if (_shouldCoalesceComposedStream(chunkSize)) {
+        yield* _streamComposedParts(chunkSize: chunkSize);
+      } else {
+        for (final part in _parts!) {
+          yield* part.block.stream(chunkSize: chunkSize);
+        }
       }
-      return;
+    } else {
+      final materialized = await ensureMaterialized();
+      yield* materialized.stream(chunkSize: chunkSize);
     }
-
-    final materialized = await ensureMaterialized();
-    yield* materialized.stream(chunkSize: chunkSize);
   }
 
   @override
@@ -660,6 +704,36 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
     }
 
     return output;
+  }
+
+  bool _shouldCoalesceComposedStream(int chunkSize) {
+    final parts = _parts!;
+    return parts.length > 8 && _length < chunkSize * parts.length;
+  }
+
+  Stream<Uint8List> _streamComposedParts({required int chunkSize}) async* {
+    final coalescer = _ChunkCoalescer(chunkSize);
+
+    for (final part in _parts!) {
+      final block = part.block;
+      if (block is MemoryBlock) {
+        for (final chunk in coalescer.add(block.copyBytesSync())) {
+          yield chunk;
+        }
+        continue;
+      }
+
+      await for (final chunk in block.stream(chunkSize: chunkSize)) {
+        for (final output in coalescer.add(chunk)) {
+          yield output;
+        }
+      }
+    }
+
+    final trailing = coalescer.finish();
+    if (trailing != null) {
+      yield trailing;
+    }
   }
 }
 

--- a/lib/src/block_file.dart
+++ b/lib/src/block_file.dart
@@ -743,11 +743,14 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
       continue;
     }
 
-    final flattenedParts = _flattenedComposedParts(normalizedPart.block);
-    if (flattenedParts == null) {
-      normalized.add(normalizedPart);
+    final block = normalizedPart.block;
+    if (block is _IoLazyBlock &&
+        block._isComposed &&
+        block._materialized == null &&
+        block._materializing == null) {
+      normalized.addAll(block._parts!);
     } else {
-      normalized.addAll(flattenedParts);
+      normalized.add(normalizedPart);
     }
     totalSize += normalizedPart.length;
   }
@@ -756,18 +759,6 @@ final class _IoLazyBlock extends BlockBase implements _IoReadable {
     parts: List<_BlockPart>.unmodifiable(normalized),
     totalSize: totalSize,
   );
-}
-
-List<_BlockPart>? _flattenedComposedParts(Block block) {
-  if (block is! _IoLazyBlock || !block._isComposed) {
-    return null;
-  }
-
-  if (block._materialized != null || block._materializing != null) {
-    return null;
-  }
-
-  return block._parts;
 }
 
 _BlockPart _normalizePart(Object part) {

--- a/test/io_block_vm_test.dart
+++ b/test/io_block_vm_test.dart
@@ -334,6 +334,36 @@ void main() {
         });
       },
     );
+
+    test('streaming File parts closes source file descriptors', () async {
+      if (!_canInspectOpenFiles()) {
+        return;
+      }
+
+      await _withIsolatedSystemTemp((tempDir) async {
+        final data = Uint8List.fromList(
+          List<int>.generate(32 * 1024, (i) => i % 256),
+        );
+        final file = File(
+          '${tempDir.path}${Platform.pathSeparator}source_stream_fd.bin',
+        );
+        await file.writeAsBytes(data);
+
+        final baseline = await _countOpenDescriptorsFor(file);
+        final block = Block(<Object>['[', file, ']']);
+
+        final streamed = <int>[];
+        await for (final chunk in block.stream(chunkSize: 4096)) {
+          streamed.addAll(chunk);
+        }
+
+        expect(
+          streamed,
+          equals(<int>['['.codeUnitAt(0), ...data, ']'.codeUnitAt(0)]),
+        );
+        expect(await _countOpenDescriptorsFor(file), equals(baseline));
+      });
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

- Coalesce small chunks for many-part composed streams.
- Flatten nested IO composed parts during normalization to remove extra lazy/generator layers.
- Stream direct `File` parts without creating a cached backing `FileBlock` handle.
- Copy `MemoryBlock` composed ranges directly into the output buffer instead of routing through slice/arrayBuffer futures.

## Benchmarks

Compared against `benchmark/results/baseline-before-segment-index-no-timeline.json` using current `benchmark/results/experiment-memory-range-fastpath-no-timeline.json`:

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| `range/many_parts_random_slice_4kb` | 283.59 us | 6.10 us | -97.8% |
| `range/many_parts_random_slice_64kb` | 514.46 us | 22.90 us | -95.5% |
| `stream/many_parts_4mb_chunk64kb` | 3246.58 us | 1015.25 us | -68.7% |
| `stream/nested_read_4mb_chunk128kb` | 153.58 us | 126.33 us | -17.7% |

Temp-file use on the many-part range paths drops to zero; RSS stays flat or slightly lower in the measured runs.

## Validation

- `dart analyze`
- `dart test`
- `git diff --check`
- `dart benchmark/run_all.dart --no-color --output=benchmark/results/experiment-memory-range-fastpath-no-timeline.json`

Refs #13